### PR TITLE
Fix for RT#55591: Incorrect default value for 'codes_to_determinate'

### DIFF
--- a/lib/LWP/UserAgent/Determined.pm
+++ b/lib/LWP/UserAgent/Determined.pm
@@ -59,7 +59,7 @@ sub new {
 sub _determined_init {
   my $self = shift;
   $self->timing( '1,3,15' );
-  $self->codes_to_determinate( { map $_=>1,
+  $self->codes_to_determinate( { map { $_=>1 }
    '408', # Request Timeout
    '500', # Internal Server Error
    '502', # Bad Gateway

--- a/t/10_determined_test.t
+++ b/t/10_determined_test.t
@@ -2,7 +2,7 @@
 # Time-stamp: "0";
 use strict;
 use Test;
-BEGIN { plan tests => 11 }
+BEGIN { plan tests => 13 }
 
 #use LWP::Debug ('+');
 
@@ -16,6 +16,10 @@ print "# Hello from ", __FILE__, "\n";
 print "# LWP::UserAgent::Determined v$LWP::UserAgent::Determined::VERSION\n";
 print "# LWP::UserAgent v$LWP::UserAgent::VERSION\n";
 print "# LWP v$LWP::VERSION\n" if $LWP::VERSION;
+
+my @error_codes = qw(408 500 502 503 504);
+ok( @error_codes == keys %{$browser->codes_to_determinate} );
+ok( @error_codes == grep { $browser->codes_to_determinate->{$_} } @error_codes );
 
 my $url = 'http://www.livejournal.com/~torgo_x/rss';
 my $before_count = 0;


### PR DESCRIPTION
https://rt.cpan.org/Public/Bug/Display.html?id=55591

This bug was reported by nick.glencross.
Here's a patch for it.

Before (v1.04):

<pre>
% perl -MLWP::UserAgent::Determined -MData::Dumper -e 'print Dumper(LWP::UserAgent::Determined->new->codes_to_determinate)'
$VAR1 = {
          '1' => '408',
          '503' => '504',
          '500' => '502'
        };
</pre>

After:

<pre>
% perl -Ilib -MLWP::UserAgent::Determined -MData::Dumper -e 'print Dumper(LWP::UserAgent::Determined->new->codes_to_determinate)'
$VAR1 = {
          '408' => 1,
          '503' => 1,
          '502' => 1,
          '500' => 1,
          '504' => 1
        };
</pre>
