### PR TITLE
Mock http responses to avoid unnecessary network requests

### DIFF
--- a/t/10_determined_test.t
+++ b/t/10_determined_test.t
@@ -36,8 +36,8 @@ $browser->before_determined_callback( sub {
   ++$before_count;
 });
 $browser->after_determined_callback( sub {
-  print "#  \\Just tried ", $_[4][0]->uri, " at ", scalar(localtime),
-    ".  Waiting " . (timings)[$after_count] . "s.\n";
+  print "#  \\Just tried ", $_[4][0]->uri, " at ", scalar(localtime), ".  ",
+    ($after_count < scalar(timings) ? "Waiting " . (timings)[$after_count] . "s." : "Giving up."), "\n";
   ++$after_count;
 });
 

--- a/t/10_determined_test.t
+++ b/t/10_determined_test.t
@@ -9,6 +9,12 @@ BEGIN { plan tests => 13 }
 use LWP::UserAgent::Determined;
 my $browser = LWP::UserAgent::Determined->new;
 
+sub timings {
+  my $self = $browser;
+  # copied from module, line 20
+  my(@timing_tries) = ( $self->timing() =~ m<(\d+(?:\.\d+)*)>g );
+}
+
 #$browser->agent('Mozilla/4.76 [en] (Win98; U)');
 
 ok 1;
@@ -30,7 +36,8 @@ $browser->before_determined_callback( sub {
   ++$before_count;
 });
 $browser->after_determined_callback( sub {
-  print "#  \\Just tried ", $_[4][0]->uri, " at ", scalar(localtime), ".\n";
+  print "#  \\Just tried ", $_[4][0]->uri, " at ", scalar(localtime),
+    ".  Waiting " . (timings)[$after_count] . "s.\n";
   ++$after_count;
 });
 

--- a/t/10_determined_test.t
+++ b/t/10_determined_test.t
@@ -9,6 +9,16 @@ BEGIN { plan tests => 13 }
 use LWP::UserAgent::Determined;
 my $browser = LWP::UserAgent::Determined->new;
 
+use HTTP::Headers;
+use HTTP::Request;
+
+sub set_response {
+  my ($code) = @_;
+  $browser->set_my_handler(request_send => @_ ? sub {
+    return HTTP::Response->new($code, undef, HTTP::Headers->new(), 'n/a');
+  } : ());
+}
+
 sub timings {
   my $self = $browser;
   # copied from module, line 20
@@ -26,6 +36,10 @@ print "# LWP v$LWP::VERSION\n" if $LWP::VERSION;
 my @error_codes = qw(408 500 502 503 504);
 ok( @error_codes == keys %{$browser->codes_to_determinate} );
 ok( @error_codes == grep { $browser->codes_to_determinate->{$_} } @error_codes );
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+set_response(503);
 
 my $url = 'http://www.livejournal.com/~torgo_x/rss';
 my $before_count = 0;
@@ -52,6 +66,8 @@ ok(  $after_count > 1 );
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+set_response(500);
+
 $url = "http://www.aoeaoeaoeaoe.int:9876/sntstn";
 $before_count = 0;
  $after_count = 0;
@@ -72,6 +88,8 @@ ok $after_count,  4;
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+set_response(404);
 
 $url = "http://www.interglacial.com/always404alicious/";
 $before_count = 0;

--- a/t/10_determined_test.t
+++ b/t/10_determined_test.t
@@ -49,7 +49,7 @@ $url = "http://www.aoeaoeaoeaoe.int:9876/sntstn";
 $before_count = 0;
  $after_count = 0;
 
-print "# Trying a nonexistent address, $url\n";
+print "# Trying unknown host/port, $url\n";
 
 $resp = $browser->get( $url );
 ok 1;


### PR DESCRIPTION
This resolves the hanging-network-tests issue of https://rt.cpan.org/Ticket/Display.html?id=71491
by overriding LWP to return canned responses instead of actually performing the network requests,
since that's really all that is necessary to test the module.
