### PR TITLE
External HTTP tests failing due to change on external webservers

### DIFF
--- a/t/10_determined_test.t
+++ b/t/10_determined_test.t
@@ -66,7 +66,7 @@ ok $after_count,  4;
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-$url = "http://www.interglacial.com/always404alicious/";
+$url = "http://www.bestpractical.com/always404alicious/";
 $before_count = 0;
  $after_count = 0;
 


### PR DESCRIPTION
Okay, so tests are failing for us on this one because it can no longer find the server it expects to get a 404 on.  Changed the server.
